### PR TITLE
Exclude success/failure in message for connect

### DIFF
--- a/lib/parsers/goAuditParser.js
+++ b/lib/parsers/goAuditParser.js
@@ -549,7 +549,7 @@ var buildMessage = function (result) {
         }
 
         // Succeeded or failed?
-        if (data.syscall.hasOwnProperty('success')) {
+        if (data.syscall.hasOwnProperty('success') && data.syscall.name !== 'connect') {
             if (data.syscall.success === 'yes') {
                 message += 'succeeded to '
             } else {


### PR DESCRIPTION
For non-blocking connect invocations connect can return errors such as
EINPROGRESS that don't really mean the syscall failed.

The previous behavior would result in a misleading message that
confused people. Now we'll just show `$user connect to $host`.