### PR TITLE
sudoParser: properly parse ENV variables

### DIFF
--- a/lib/parsers/sudoParser.js
+++ b/lib/parsers/sudoParser.js
@@ -1,13 +1,13 @@
 var regexes = [
     {
         name: 'command',
-        regex: /^(.+) : TTY=(.+) ; PWD=(.+) ; USER=(.+) ; COMMAND=(.*)/,
-        parts: [ 'user', 'tty', 'pwd', 'as_user', 'command' ]
+        regex: /^(.+) : TTY=(.+) ; PWD=(.+) ; USER=(.+?) ;(?: ENV=(.+) ;)? COMMAND=(.*)/,
+        parts: [ 'user', 'tty', 'pwd', 'as_user', 'env', 'command' ]
     },
     {
         name: 'error',
-        regex: /^(.+) : (.+?) ; TTY=(.+) ; PWD=(.+) ; USER=(.+) ; COMMAND=(.*)/,
-        parts: [ 'user', 'error', 'tty', 'pwd', 'as_user', 'command' ]
+        regex: /^(.+) : (.+?) ; TTY=(.+) ; PWD=(.+) ; USER=(.+?) ;(?: ENV=(.+) ;)? COMMAND=(.*)/,
+        parts: [ 'user', 'error', 'tty', 'pwd', 'as_user', 'env', 'command' ]
     },
 ]
 
@@ -37,7 +37,9 @@ module.exports = function (message) {
 
     data.event = matched.name
     matched.parts.forEach(function (name, index) {
-        data[name] = parts[index + 1].trim()
+        if (parts[index + 1] !== undefined) {
+            data[name] = parts[index + 1].trim()
+        }
     })
 
     return { data: data, error: void 0 }

--- a/test/parsers/sudoParser.test.js
+++ b/test/parsers/sudoParser.test.js
@@ -34,4 +34,36 @@ describe('sudoParser', function () {
         )
     })
 
+    it('Should parse ENV variables properly', function () {
+        assertParserResult(
+            StreamStash.parsers.sudoParser.raw,
+            '    ubuntu : TTY=pts/0 ; PWD=/home/ubuntu ; USER=root ; ENV=FOO=1 BAR=2 ; COMMAND=/bin/ls -l',
+            {
+                as_user: 'root',
+                command: '/bin/ls -l',
+                event: 'command',
+                pwd: '/home/ubuntu',
+                env: 'FOO=1 BAR=2',
+                tty: 'pts/0',
+                user: 'ubuntu'
+            }
+        )
+    })
+
+    it('Should parse ENV variables properly in the error case', function () {
+        assertParserResult(
+            StreamStash.parsers.sudoParser.raw,
+            '    ubuntu : command not allowed ; TTY=pts/0 ; PWD=/home/ubuntu ; USER=root ; ENV=FOO=1 BAR=2 ; COMMAND=/bin/ls -l',
+            {
+                as_user: 'root',
+                command: '/bin/ls -l',
+                error: 'command not allowed',
+                event: 'error',
+                pwd: '/home/ubuntu',
+                env: 'FOO=1 BAR=2',
+                tty: 'pts/0',
+                user: 'ubuntu'
+            }
+        )
+    })
 })


### PR DESCRIPTION
Running a command: `sudo FOO=1 /some/cmd` will cause sudo to log the
environment variable FOO. We previously were incorrectly capturing
that as part of the 'as_user' field. We now properly capture the ENV
field.