### PR TITLE
Plumb through go-audit.extras field

### DIFF
--- a/lib/parsers/goAuditParser.js
+++ b/lib/parsers/goAuditParser.js
@@ -299,6 +299,10 @@ var gatherTypesAndContainers = function (data, result) {
         if (msg.hasOwnProperty('containers')) {
             result.data.containers = msg.containers
         }
+
+        if (msg.hasOwnProperty('extras')) {
+            result.data.extras = msg.extras
+        }
     }
 
     return groups


### PR DESCRIPTION
This is a generic bucket for extra parsers to pass additional metadata
along.